### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/59221469/35cd70d3-1a27-4aa4-b2f1-a5b5ad745c0a/9729ea1c-c908-4ee3-9066-c16d4d5ec928/_apis/work/boardbadge/6fecf8b9-6022-4561-ab00-e9d004deaf94)](https://dev.azure.com/59221469/35cd70d3-1a27-4aa4-b2f1-a5b5ad745c0a/_boards/board/t/9729ea1c-c908-4ee3-9066-c16d4d5ec928/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/59221469/35cd70d3-1a27-4aa4-b2f1-a5b5ad745c0a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.